### PR TITLE
add public path to MiniCssExtractPlugin

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -27,7 +27,6 @@ module.exports = {
   },
 
   output: {
-    publicPath: "/dist/",
     assetModuleFilename: "assets/[hash][ext][query]",
     clean: true,
   },
@@ -66,6 +65,9 @@ module.exports = {
         use: [
           {
             loader: MiniCssExtractPlugin.loader,
+            options: {
+              publicPath: "",
+            },
           },
           "css-loader",
           "postcss-loader",


### PR DESCRIPTION
# Description

WebView does not support automatic public path , so it must be configured manually



## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
