### PR TITLE
Fix broken external links on Linux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ dist
 
 # Build folder
 build
+
+# Code - OSS folder
+.vscode

--- a/src/backend/api/bind.hpp
+++ b/src/backend/api/bind.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "webview.h"
+#include "json.hpp"
 
 #include "window/window.hpp"
 #include "filesystem/fs.hpp"
@@ -10,6 +11,7 @@
 #include "sys/hardware/mem.hpp"
 
 extern webview::webview w;
+using json = nlohmann::json;
 
 namespace api {
 


### PR DESCRIPTION
# Description
On Linux, external links with `target=_blank` didn't work because of webkitgtk policy. Now, all external links with any `target` are working on Linux

Fixes #26 (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
