### PR TITLE
Add new functions to `overfs` library

### DIFF
--- a/src/backend/api/bind.hpp
+++ b/src/backend/api/bind.hpp
@@ -19,11 +19,14 @@ namespace api {
     std::map<std::string, FnPtr> Functions = {
         {"win_closeWindow", api::CloseWindow},
 
-        {"fs_makeDir", api::MakeDirectory},
+        {"fs_makeDir", api::MakeDir},
         {"fs_readFile", api::ReadFile},
         {"fs_writeFile", api::WriteFile},
         {"fs_appendFile", api::AppendFile},
         {"fs_removeFile", api::RemoveFile},
+        {"fs_removeDir", api::RemoveDir},
+        {"fs_listDir", api::ListDir},
+        {"fs_absolutePath", api::AbsolutePath},
 
         {"sys_version", api::Version},
         {"sys_platform", api::Platform},
@@ -89,7 +92,7 @@ namespace api {
 
         // Takes as argument path where dir has to be created
         // JS: function fs_makeDir(path)
-        w.bind("fs_makeDir", api::MakeDirectory);
+        w.bind("fs_makeDir", api::MakeDir);
 
         // Takes path to file as argument and reads file
         // JS: function fs_readFile(filename)
@@ -110,12 +113,12 @@ namespace api {
 
         // Do the same as function above, but can delete directory with files
         // JS: function fs_removeDir(dirname)
-        w.bind("fs_removeDir", api::RemoveDirectory);
+        w.bind("fs_removeDir", api::RemoveDir);
 
         // Takes directory as argument. Lists directory and returns array of
         // files
         // JS: function fs_listDir(dirname)
-        w.bind("fs_listDir", api::ListDirectory);
+        w.bind("fs_listDir", api::ListDir);
 
         // Takes relative path as argument. Converts relative path to absolute
         // JS: function fs_absolutePath(path)

--- a/src/backend/api/bind.hpp
+++ b/src/backend/api/bind.hpp
@@ -108,6 +108,19 @@ namespace api {
         // JS: function fs_removeFile(filename)
         w.bind("fs_removeFile", api::RemoveFile);
 
+        // Do the same as function above, but can delete directory with files
+        // JS: function fs_removeDir(dirname)
+        w.bind("fs_removeDir", api::RemoveDirectory);
+
+        // Takes directory as argument. Lists directory and returns array of
+        // files
+        // JS: function fs_listDir(dirname)
+        w.bind("fs_listDir", api::ListDirectory);
+
+        // Takes relative path as argument. Converts relative path to absolute
+        // JS: function fs_absolutePath(path)
+        w.bind("fs_absolutePath", api::AbsolutePath);
+
         // Doesn't take any arguments. Returns system version, for example:
         // Linux (6.0.6-arch1-1)
         // JS: function sys_version()

--- a/src/backend/api/filesystem/fs.cpp
+++ b/src/backend/api/filesystem/fs.cpp
@@ -3,7 +3,7 @@
 namespace api {
 
 
-    std::string MakeDirectory(std::string args) {
+    std::string MakeDir(std::string args) {
 
         json arr = json::parse(args);
         std::string path = arr[0].get<std::string>();
@@ -74,7 +74,7 @@ namespace api {
         return std::filesystem::remove(filename) ? "\"true\"" : "\"false\"";
     }
 
-    std::string RemoveDirectory(std::string args) {
+    std::string RemoveDir(std::string args) {
 
         json arr = json::parse(args);
         std::string dirname = arr[0].get<std::string>();
@@ -82,7 +82,7 @@ namespace api {
         return std::filesystem::remove_all(dirname) ? "\"true\"" : "\"false\"";
     }
 
-    std::string ListDirectory(std::string args) {
+    std::string ListDir(std::string args) {
 
         json arr = json::parse(args);
         json ret;

--- a/src/backend/api/filesystem/fs.cpp
+++ b/src/backend/api/filesystem/fs.cpp
@@ -74,5 +74,33 @@ namespace api {
         return std::filesystem::remove(filename) ? "\"true\"" : "\"false\"";
     }
 
+    std::string RemoveDirectory(std::string args) {
+
+        json arr = json::parse(args);
+        std::string dirname = arr[0].get<std::string>();
+
+        return std::filesystem::remove_all(dirname) ? "\"true\"" : "\"false\"";
+    }
+
+    std::string ListDirectory(std::string args) {
+
+        json arr = json::parse(args);
+        json ret;
+        std::string dirname = arr[0].get<std::string>();
+
+        for (const auto& entry : std::filesystem::directory_iterator(dirname))
+            ret.push_back(entry.path());
+
+        return ret.dump();
+    }
+
+    std::string AbsolutePath(std::string args) {
+
+        json arr = json::parse(args);
+        std::string path = arr[0].get<std::string>();
+
+        return "\"" + std::filesystem::absolute(path).u8string() + "\"";
+    }
+
 
 }; // namespace api

--- a/src/backend/api/filesystem/fs.hpp
+++ b/src/backend/api/filesystem/fs.hpp
@@ -11,13 +11,13 @@ using json = nlohmann::json;
 namespace api {
 
 
-    std::string MakeDirectory(std::string args);
+    std::string MakeDir(std::string args);
     std::string ReadFile(std::string args);
     std::string WriteFile(std::string args);
     std::string AppendFile(std::string args);
     std::string RemoveFile(std::string args);
-    std::string RemoveDirectory(std::string args);
-    std::string ListDirectory(std::string args);
+    std::string RemoveDir(std::string args);
+    std::string ListDir(std::string args);
     std::string AbsolutePath(std::string args);
 
 

--- a/src/backend/api/filesystem/fs.hpp
+++ b/src/backend/api/filesystem/fs.hpp
@@ -16,6 +16,9 @@ namespace api {
     std::string WriteFile(std::string args);
     std::string AppendFile(std::string args);
     std::string RemoveFile(std::string args);
+    std::string RemoveDirectory(std::string args);
+    std::string ListDirectory(std::string args);
+    std::string AbsolutePath(std::string args);
 
 
 }; // namespace api


### PR DESCRIPTION
# Description

Add three new functions to the `overfs` library. Functions that were introduced
- `std::string RemoveDirectory(std::string args)`
- `std::string ListDirectory(std::string args)`
- `std::string AbsolutePath(std::string args)`

These functions are bound into JS and can be used from frontend.

### What kind of change does this PR introduce?

- [x] Feature

### Does this PR introduce a breaking change?

- [x] No

### Other information
