### PR TITLE
fix broken function fs_appendFile

### DIFF
--- a/src/backend/api/filesystem/fs.cpp
+++ b/src/backend/api/filesystem/fs.cpp
@@ -65,6 +65,7 @@ namespace api {
     std::string AppendFile(std::string args) {
 
         Document d;
+        d.Parse(args.c_str());
         std::string filename = d[0].GetString();
 
         std::ofstream f(filename, std::ios_base::app);


### PR DESCRIPTION
# Description

Function `fs_appendFile` didn't parse the arguments and when invoking, crashes application, because it tries to use parsed arguments, that literally even not parsed. Now, it's fixed

Fixed issue #34 

### What kind of change does this PR introduce?

- [x] Bugfix

### Does this PR introduce a breaking change?

<!-- If yes, please describe the impact -->

- [x] No
