### PR TITLE
remove import due to broken function invoking in js

### DIFF
--- a/src/backend/api/bind.hpp
+++ b/src/backend/api/bind.hpp
@@ -13,8 +13,6 @@
 #include "sys/hardware/display.hpp"
 #include "sys/hardware/mem.hpp"
 
-#include <iostream>
-
 extern webview::webview w;
 using namespace rapidjson;
 
@@ -96,18 +94,6 @@ namespace api {
         return JNoRet;
     }
 
-    std::string Import(std::string args) {
-
-        Document d;
-        d.Parse(args.c_str());
-
-        std::string Func = d[0].GetString();
-
-        w.bind(Func, Functions[Func]);
-
-        return JNoRet;
-    }
-
     void BindInit() noexcept {
 
         // Takes 2 arguments and resizes window
@@ -131,16 +117,6 @@ namespace api {
         // necessary for this function and variable name (last argument)
         // JS: function asyncWithValue()
         w.bind("asyncWithValue", api::AsyncCPP);
-
-        // Takes as argument function name and binds it to JS
-        // JS: function importFromCXX()
-        w.bind("importFromCXX", api::Import);
-    }
-
-}; // namespace api
-
-
-/*
 
         // Takes as argument path where dir has to be created
         // JS: function fs_makeDir(path)
@@ -230,5 +206,6 @@ namespace api {
         // currently in use by this process
         // JS: function sys_procVirtualMemoryUsage()
         w.bind("sys_procVirtualMemoryUsage", api::GetProcVirtualMemoryUsage);
+    }
 
-*/
+}; // namespace api


### PR DESCRIPTION
# Description

Function `importFromCXX` had to import C++ functions into JS, but literally these functions were not accessible in JS even after importing, so this function is deprecated and now no longer used.

### What kind of change does this PR introduce?

- [x] Bugfix

### Does this PR introduce a breaking change?

- [x] No
